### PR TITLE
Ignore `src/lib.rs` or `src/main.rs` depending on crate type

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,5 +1,5 @@
 [template]
-cargo_generate_version = ">=0.7.0"
+cargo_generate_version = ">=0.10.0"
 
 [placeholders.username]
 type = "string"
@@ -8,3 +8,9 @@ prompt = "GitHub username (or organization)?"
 [placeholders.project-description]
 type = "string"
 prompt = "Project description?"
+
+[conditional.'crate_type == "lib"']
+ignore = [ "src/main.rs" ]
+
+[conditional.'crate_type == "bin"']
+ignore = [ "src/lib.rs" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}


### PR DESCRIPTION
Related issue: #12 
