### PR TITLE
rename `{{username}}` to `{{gh-username}}`

### DIFF
--- a/.github/workflows/template_values.toml
+++ b/.github/workflows/template_values.toml
@@ -1,3 +1,3 @@
 [values]
-username = "rust-github"
+gh-username = "rust-github"
 project-description = "Example of Rust GitHub template"

--- a/template/.github/PULL_REQUEST_TEMPLATE.md
+++ b/template/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,10 +3,10 @@
 <!--
 Please, make sure:
 - you have read the contributing guidelines:
-  https://github.com/{{username}}/{{project-name}}/blob/main/docs/CONTRIBUTING.md
+  https://github.com/{{gh-username}}/{{project-name}}/blob/main/docs/CONTRIBUTING.md
 - you have formatted the code using rustfmt:
   https://github.com/rust-lang/rustfmt
 - you have checked that all tests pass, by running `cargo test --all`
 - you have updated the changelog (if needed):
-  https://github.com/{{username}}/{{project-name}}/blob/main/CHANGELOG.md
+  https://github.com/{{gh-username}}/{{project-name}}/blob/main/CHANGELOG.md
 -->

--- a/template/CONTRIBUTING.md
+++ b/template/CONTRIBUTING.md
@@ -8,7 +8,7 @@ wish to make by creating a new issue before making the change.
 ## Reporting issues
 
 Before reporting an issue on the
-[issue tracker](https://github.com/{{username}}/{{project-name}}/issues),
+[issue tracker](https://github.com/{{gh-username}}/{{project-name}}/issues),
 please check that it has not already been reported by searching for some related
 keywords.
 
@@ -19,7 +19,7 @@ Try to do one pull request per change.
 ### Updating the changelog
 
 Update the changes you have made in
-[CHANGELOG](https://github.com/{{username}}/{{project-name}}/blob/main/CHANGELOG.md)
+[CHANGELOG](https://github.com/{{gh-username}}/{{project-name}}/blob/main/CHANGELOG.md)
 file under the **Unreleased** section.
 
 Add the changes of your pull request to one of the following subsections,
@@ -42,7 +42,7 @@ If the required subsection does not exist yet under **Unreleased**, create it!
 This is no different than other Rust projects.
 
 ```shell
-git clone https://github.com/{{username}}/{{project-name}}
+git clone https://github.com/{{gh-username}}/{{project-name}}
 cd {{project-name}}
 cargo test
 ```

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -3,7 +3,7 @@ name = "{{project-name}}"
 version = "0.1.0"
 edition = "2021"
 description = "{{project-description}}"
-repository = "https://github.com/{{username}}/{{project-name}}"
+repository = "https://github.com/{{gh-username}}/{{project-name}}"
 license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/template/README.md
+++ b/template/README.md
@@ -2,8 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/{{project-name}}.svg)](https://crates.io/crates/{{project-name}})
 [![Docs.rs](https://docs.rs/{{project-name}}/badge.svg)](https://docs.rs/{{project-name}})
-[![CI](https://github.com/{{username}}/{{project-name}}/workflows/CI/badge.svg)](https://github.com/{{username}}/{{project-name}}/actions)
-[![Coverage Status](https://coveralls.io/repos/github/{{username}}/{{project-name}}/badge.svg?branch=main)](https://coveralls.io/github/{{username}}/{{project-name}}?branch=main)
+[![CI](https://github.com/{{gh-username}}/{{project-name}}/workflows/CI/badge.svg)](https://github.com/{{gh-username}}/{{project-name}}/actions)
+[![Coverage Status](https://coveralls.io/repos/github/{{gh-username}}/{{project-name}}/badge.svg?branch=main)](https://coveralls.io/github/{{gh-username}}/{{project-name}}?branch=main)
 
 ## Installation
 

--- a/template/cargo-generate.toml
+++ b/template/cargo-generate.toml
@@ -1,7 +1,7 @@
 [template]
 cargo_generate_version = ">=0.10.0"
 
-[placeholders.username]
+[placeholders.gh-username]
 type = "string"
 prompt = "GitHub username (or organization)?"
 


### PR DESCRIPTION
This is needed because the placeholder `{{username}}` is now reserved after https://github.com/cargo-generate/cargo-generate/commit/86bd44b49a0b9acf0fa09bdbdd49db7fcc88abf8 