### PR TITLE
ci: remove some `actions-rs` and `publish-dry-run` step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,7 @@ jobs:
           subfolder: template
           template_values_file: .github/workflows/template_values.toml
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Cargo check
         # we need to move the generated project to a temp folder, away from the template project
         # otherwise `cargo` runs would fail

--- a/template/.github/workflows/audit.yml
+++ b/template/.github/workflows/audit.yml
@@ -17,12 +17,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       # Ensure that the latest version of Cargo is installed
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/audit-check@v1
         with:

--- a/template/.github/workflows/cd.yml
+++ b/template/.github/workflows/cd.yml
@@ -116,14 +116,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
+      - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        with:
-          command: publish

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --all-features --workspace
+      - name: Run tests
+        run: cargo test --all-features --workspace
 
   rustfmt:
     name: Rustfmt
@@ -30,7 +31,8 @@ jobs:
         with:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
-      - run: cargo fmt --all --check
+      - name: Check formatting
+        run: cargo fmt --all --check
 
   clippy:
     name: Clippy
@@ -43,7 +45,8 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --all-targets --all-features --workspace -- -D warnings
+      - name: Clippy check
+        run: cargo clippy --all-targets --all-features --workspace -- -D warnings
 
   docs:
     name: Docs
@@ -57,5 +60,5 @@ jobs:
       - name: Check documentation
         env:
           RUSTDOCFLAGS: -D warnings
-      - run: cargo doc --no-deps --document-private-items --all-features --workspace --examples
+        run: cargo doc --no-deps --document-private-items --all-features --workspace --examples
 {% endraw  %}

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -15,16 +15,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features --workspace
+      - run: cargo test --all-features --workspace
 
   rustfmt:
     name: Rustfmt
@@ -33,18 +26,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
-      - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all --check
+      - run: cargo fmt --all --check
 
   clippy:
     name: Clippy
@@ -53,18 +39,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - name: Clippy check
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features --workspace -- -D warnings
+      - run: cargo clippy --all-targets --all-features --workspace -- -D warnings
 
   docs:
     name: Docs
@@ -73,35 +52,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Check documentation
         env:
           RUSTDOCFLAGS: -D warnings
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --no-deps --document-private-items --all-features --workspace --examples
-
-  publish-dry-run:
-    name: Publish dry run
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --dry-run
+      - run: cargo doc --no-deps --document-private-items --all-features --workspace --examples
 {% endraw  %}


### PR DESCRIPTION
The `publish-dry-run` is not always working. 
`actions-rs` are unmaintained.