### PR TITLE
feat(ci): add llvm-cov to template ci

### DIFF
--- a/template/.github/workflows/audit.yml
+++ b/template/.github/workflows/audit.yml
@@ -16,11 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      # Ensure that the latest version of Cargo is installed
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/audit-check@v1
+      - name: Run security audit
+        uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 {% endraw  %}

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -75,5 +75,9 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          file: lcov.info
 {% endraw  %}
 

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -61,4 +61,19 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
         run: cargo doc --no-deps --document-private-items --all-features --workspace --examples
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 {% endraw  %}
+


### PR DESCRIPTION
This adds the cut/paste llvm-cov job from the [docs](https://github.com/taiki-e/cargo-llvm-cov?tab=readme-ov-file#continuous-integration).

I tested this by creating a project with the template and put it here: <https://github.com/joshrotenberg/rust-template-llvm-cov-test>

I removed the call to upload the coverage file in the workflow because it requires the token in secrets, which means the workflow fails by default, which seems bad, but I'm open to suggestions.

Fixes #44 