### PR TITLE
fix(ci): upadte audit action to use rustsec version

### DIFF
--- a/template/.github/workflows/audit.yml
+++ b/template/.github/workflows/audit.yml
@@ -16,11 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      # Ensure that the latest version of Cargo is installed
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/audit-check@v1
+      - name: Run security audit
+        uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 {% endraw  %}


### PR DESCRIPTION
actions-rs is no longer maintained. The audit action was forked and now lives here: <https://github.com/rustsec/audit-check>

Update to use this instead.

Part of #42.