### PR TITLE
build(deps): bump rustsec/audit-check from 1.4.1 to 2.0.0

### DIFF
--- a/template/.github/workflows/audit.yml
+++ b/template/.github/workflows/audit.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Run security audit
-        uses: rustsec/audit-check@v1.4.1
+        uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 {% endraw  %}


### PR DESCRIPTION
I created a project recently using this template and dependabot immediately suggested this.

Thanks for this template btw! 

P.s.: If I could make a suggestion: is it possible to choose to exclude parts of the CD during project creating if my Rust crate is not a binary?