### PR TITLE
Give permission to CD action to make releases

### DIFF
--- a/template/.github/workflows/cd.yml
+++ b/template/.github/workflows/cd.yml
@@ -10,6 +10,8 @@ jobs:
   publish:
     name: Publishing for {{ "${{ matrix.job.os }}" }}
     runs-on: {{ "${{ matrix.job.os }}" }}
+    permissions:
+      contents: write
     strategy:
       matrix:
         rust: [stable]


### PR DESCRIPTION
Without this, the CD action fails. This requirement is listed in the [README](https://github.com/softprops/action-gh-release?tab=readme-ov-file#permissions) of `softprops/action-gh-release`.