### PR TITLE
Bump softprops/action-gh-release from 1 to 2

### DIFF
--- a/template/.github/workflows/cd.yml
+++ b/template/.github/workflows/cd.yml
@@ -104,7 +104,7 @@ jobs:
             shasum -a 256 $RELEASE_NAME.tar.gz > $RELEASE_NAME.sha256
           fi
       - name: Releasing assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             target/{{ "${{ matrix.job.target }}" }}/release/{{project-name}}-*.tar.gz


### PR DESCRIPTION
Dependabot will do this immediately to any repository that is based off of this template. There do not seem to be any breaking changes associated with this version bump.