### PR TITLE
feat: Cache cargo-audit binary

### DIFF
--- a/template/.github/workflows/audit.yml
+++ b/template/.github/workflows/audit.yml
@@ -16,10 +16,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cargo/bin/cargo-audit
-          key: ${{ runner.os }}-cargo-audit
+      - uses: Swatinem/rust-cache@v2
       - name: Run security audit
         uses: rustsec/audit-check@v2.0.0
         with:

--- a/template/.github/workflows/audit.yml
+++ b/template/.github/workflows/audit.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: ${{ runner.os }}-cargo-audit
       - name: Run security audit
         uses: rustsec/audit-check@v2.0.0
         with:


### PR DESCRIPTION
Only build the binary once and cache it to speed up subsequent workflow runs.